### PR TITLE
Fix empty string highlighting

### DIFF
--- a/syntax/rego.vim
+++ b/syntax/rego.vim
@@ -24,7 +24,7 @@ syn match regoNumber "\<\(0[0-7]*\|0[xx]\x\+\|\d\+\)[ll]\=\>"
 syn match regoNumber "\(\<\d\+\.\d*\|\.\d\+\)\([ee][-+]\=\d\+\)\=[ffdd]\="
 syn match regoNumber "\<\d\+[ee][-+]\=\d\+[ffdd]\=\>"
 syn match regoNumber "\<\d\+\([ee][-+]\=\d\+\)\=[ffdd]\>"
-syn region regoString start="\"[^"]" skip="\\\"" end="\"" contains=regoStringEscape
+syn region regoString start="\"" skip="\\\"" end="\"" contains=regoStringEscape
 syn match regoStringEscape "\\u[0-9a-fA-F]\{4}" contained
 syn match regoStringEscape "\\[nrfvb\\\"]" contained
 


### PR DESCRIPTION
An empty string was not correctly highlighting as a string - the highlight continued for the rest of the file as though the string was not terminated.

First time editing a vim syntax highlight script!  I am unsure about unintended side-effects of this change :)