### PR TITLE
Add missing ftdetect autocmds for comments

### DIFF
--- a/ftdetect/rego.vim
+++ b/ftdetect/rego.vim
@@ -1,5 +1,5 @@
 autocmd BufRead,BufNewFile *.rego set filetype=rego
 
 " Use # as a comment prefix
-setlocal comments=b:#,fb:-
-setlocal commentstring=#\ %s
+autocmd FileType rego setlocal comments=b:#,fb:-
+autocmd FileType rego setlocal commentstring=#\ %s


### PR DESCRIPTION
Resolves #7

As far as I understand, without these `autocmd` additions the settings would apply to any filetype.