### PR TITLE
automatically highlight .rq files as Rego

### DIFF
--- a/ftdetect/rego.vim
+++ b/ftdetect/rego.vim
@@ -1,4 +1,5 @@
 autocmd BufRead,BufNewFile *.rego set filetype=rego
+autocmd BufRead,BufNewFile *.rq set filetype=rego
 
 " Use # as a comment prefix
 autocmd FileType rego setlocal comments=b:#,fb:-


### PR DESCRIPTION
This PR causes the vim-rego plugin to recognize `.rq` files as Rego, in addition to `.rego`. It should not modify the behavior of this plugin for `.rego` files. I tested it for both `.rego` and `.rq` on my machine with NeoVim v0.9.2.

Cross-reference: [rq #5](https://todo.sr.ht/~charles/rq/5). 